### PR TITLE
fix "Module file's minimum deployment target is ios10.1"

### DIFF
--- a/Dollar.xcodeproj/project.pbxproj
+++ b/Dollar.xcodeproj/project.pbxproj
@@ -232,6 +232,7 @@
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
 				INFOPLIST_FILE = Dollar.xcodeproj/Dollar_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -261,6 +262,7 @@
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
 				INFOPLIST_FILE = Dollar.xcodeproj/Dollar_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";


### PR DESCRIPTION
Recently I upgrade my code to swift 3. 
After i upgrade dollar to latest version, i got the error "Module file's minimum deployment target is ios10.1". Fix it by specify deployment target to iOS 8.
You should also test the solution again because i have not finished my upgrade. 