### PR TITLE
Add a sum function for arrays of type Int or Double

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,6 +576,16 @@ $.contains(arr, value: $.sample(arr))
 => true
 ```
 
+### sum - `$.sum`
+
+Returns the sum of Integers or Double of the array
+
+```swift
+let arr : Int[] = [5, 10, 5]
+$.sum(arr)
+=> 20
+```
+
 ### sequence - `$.sequence`
 
 Creates an array of an arbitrary sequence. Especially useful with builtin ranges.

--- a/Sources/Dollar.swift
+++ b/Sources/Dollar.swift
@@ -1236,6 +1236,22 @@ open class `$` {
         return array.count
     }
 
+    /// Return the sum of an array of integer numbers
+    ///
+    /// - parameter array: The array to source from.
+    /// - returns: Sum of all int of the array
+    open class func sum(_ array: [Int]) -> Int {
+        return self.reduce(array, initial: 0) { (total, num) in total + num }
+    }
+
+    /// Return the sum of an array of float numbers
+    ///
+    /// - parameter array: The array to source from.
+    /// - returns: Sum of all floats of the array
+    open class func sum(_ array: [Double]) -> Double {
+        return self.reduce(array, initial: 0.0) { (total, num) in total + num }
+    }
+
     /// Invokes interceptor with the object and then returns object.
     ///
     /// - parameter object: Object to tap into.

--- a/Tests/DollarTests/DollarTests.swift
+++ b/Tests/DollarTests/DollarTests.swift
@@ -273,6 +273,16 @@ class DollarTests: XCTestCase {
         XCTAssertTrue(`$`.contains(arr, value: `$`.sample(arr)), "Returns sample which is an element from the array")
     }
 
+    func testSumInt() {
+        let arr = [5, 5, 10]
+        XCTAssertEqual(`$`.sum(arr), 20, "Returns the sum of an array of integers")
+    }
+
+    func testSumDouble() {
+        let arr = [21.2, 10.8, 10.0]
+        XCTAssertEqual(`$`.sum(arr), 42.0, "Returns the sum of an array of double numbers")
+    }
+
     func testPluck() {
         let arr = [["age": 20], ["age": 30], ["age": 40]]
         XCTAssertEqual(`$`.pluck(arr, value: "age"), [20, 30, 40], "Returns values from the object where they key is the value")


### PR DESCRIPTION
Introduce a new method, `$.sum`, which accepts as parameter an array of `Int` or `Double`, and simple return the resulting sum. 👇 

```swift
$.sum([1, 2, 3])
=> 6
```

The reason for this, is that I think is more easy/practical to do a `$.sum(arr)` than have to write a `$.reduce(arr, initial: 0) { ... }` call. 

Any thoughts?