### PR TITLE
Added a Swift package tools version to Package.swift.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,3 +1,5 @@
+// swift-tools-version:5.0
+
 import PackageDescription
 
 let package = Package(name: "Dollar")


### PR DESCRIPTION
Running `swift package dump-package` assumes an old version of Swift which is no longer supported without a tools version being specified.

```
 $ swift package dump-package
/Users/dave/Desktop/Dollar: error: package at '/Users/dave/Desktop/Dollar' is using Swift tools version 3.1.0 which is no longer supported; use 4.0.0 or newer instead
```

I have a feeling that this Package.swift needs a little more work, but hopefully this is a start!