### PR TITLE
Update Package.swift to Support Swift Package Manager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,15 @@
-// swift-tools-version:5.0
-
+// swift-tools-version:5.1
 import PackageDescription
 
-let package = Package(name: "Dollar")
+let package = Package(
+    name: "Dollar",
+    platforms: [
+        .iOS(.v9),
+    ],
+    products: [
+        .library(name: "Dollar", targets: ["Dollar"]),
+    ],
+    targets: [
+        .target(name: "Dollar", path: "Sources")
+    ]
+)


### PR DESCRIPTION
In order to use Swift Package Manager to add Dollar as a dependency in Xcode 11, the `Package.swift` file must specify at least one target.

This PR updates Package.swift to add Dollar as a target.